### PR TITLE
Fixed build problems from zeroize

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4.0"
 rand = "0.7.3"
 rand_core = "0.5.1"
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", tag = "2.0.0"}
-paillier = { git = "https://github.com/KZen-networks/rust-paillier", tag = "v0.3.4"}
+paillier = { git = "https://github.com/shubho/rust-paillier.git"}
 rayon = "1.3.0"
 serde = { version = "1.0.104", features = ["derive"] }
 bincode = "1.2.1"


### PR DESCRIPTION
Forked from mortendahl/rust-paillier to get same functionaliy of existing rust-paillier crate. Existing rust-paillier crate does not compile due to dependency on zeroize 0.1.0

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Build was broken due since `rust-paillier` 0.3.4 depended on `curv` which depended on `zeroize` 0.1.0. We could move to `rust-paillier` 0.3.9 but that changes the `BigInt` class completely. Went back to `mortendahl/rust-paillier` 0.2.0 but that does not compile since it clashed with `ring` which also needed by `rustls`. Forked `mortendahl/rust-paillier` and updated `ring` to at least `0.16.5`. Also made `serialize` publicly visible. Anyway this is a temporary patch - we wiil replace Paillier with Cupcake

Issue - https://github.com/facebookresearch/Private-ID/issues/11

## How Has This Been Tested (if it applies)

1. Ran `cargo test`
2. Ran all three examples
3. Ran `cargo bench`
## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
