### PR TITLE
add PS3I XOR into docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ cp bin/release/private-id-server exec  && \
 cp bin/release/private-id-client exec  && \
 cp bin/release/cross-psi-server exec && \
 cp bin/release/cross-psi-client exec && \
+cp bin/release/cross-psi-xor-server exec && \
+cp bin/release/cross-psi-xor-client exec && \
 cp bin/release/pjc-client exec && \
 cp bin/release/pjc-server exec && \
 cp bin/release/datagen exec
@@ -33,4 +35,3 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=build /opt/private-id/exec /opt/private-id/bin
 WORKDIR /opt/private-id
-


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
Currently in the Dockerfile, it include cross-psi-server and cross-psi-client. However, in the new experiment we will be testing the PS3I XOR version. These two are missing in the Dockerfile.

## How Has This Been Tested (if it applies)
```
docker build -t private-id-test-ps3i .
```
And the docker build succeed.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
