### PR TITLE
Upgrade AWS SDK to v0.0.26-alpha

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,8 @@ hex = "0.3.0"
 serde = {version = "1.0.104", features = ["derive"] }
 num = "0.2.1"
 wasm-timer = "0.2.5"
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.9-alpha", package = "aws-sdk-s3" }
+aws-config = "0.0.26-alpha"
+aws-sdk-s3 = "0.0.26-alpha"
 lazy_static = "1.4.0"
 regex = "1.5.4"
 tempfile = "3.2.0"

--- a/common/src/s3_path.rs
+++ b/common/src/s3_path.rs
@@ -46,8 +46,8 @@ impl S3Path {
 
     pub async fn copy_to_local(&self) -> Result<String, std::io::Error> {
         let region = aws_sdk_s3::Region::new(self.get_region().clone());
-        let aws_cfg = aws_sdk_s3::Config::builder().region(&region).build();
-        let client = aws_sdk_s3::Client::from_conf(aws_cfg);
+        let aws_cfg = aws_config::from_env().region(region).load().await;
+        let client = aws_sdk_s3::Client::new(&aws_cfg);
         let resp = client.get_object()
             .bucket(self.get_bucket_name())
             .key(self.get_key())
@@ -70,8 +70,8 @@ impl S3Path {
         let body = aws_sdk_s3::ByteStream::from_path(path.as_ref()).await
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Failed to read path as ByteStream"))?;
         let region = aws_sdk_s3::Region::new(self.get_region().clone());
-        let aws_cfg = aws_sdk_s3::Config::builder().region(&region).build();
-        let client = aws_sdk_s3::Client::from_conf(aws_cfg);
+        let aws_cfg = aws_config::from_env().region(region).load().await;
+        let client = aws_sdk_s3::Client::new(&aws_cfg);
         client.put_object()
             .bucket(self.get_bucket_name())
             .key(self.get_key())


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
* Mitigate sevs: S253185, S253641
* This makes it so that files can be read from S3 using many more credential providers. Previously, only ENV variables were supported. Now, multiple providers are supported, included role assumption from ECS containers.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

* cargo +nightly test --release. Had to run it with release otherwise it takes forever.
* Verified that ECS role assumption properly works by running a private lift test E2E, including the id match stage

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
