### PR TITLE
Add metric logging

### DIFF
--- a/protocol-rpc/src/rpc/private-id/rpc_server.rs
+++ b/protocol-rpc/src/rpc/private-id/rpc_server.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use tonic::{Code, Request, Response, Status, Streaming};
 
+mod metrics;
 use common::{gcs_path::GCSPath, s3_path::S3Path, timer};
 use protocol::private_id::{company::CompanyPrivateId, traits::CompanyPrivateIdProtocol};
 use rpc::proto::{
@@ -36,6 +37,7 @@ pub struct PrivateIdService {
     input_with_headers: bool,
     na_val: Option<String>,
     use_row_numbers: bool,
+    metrics_path: Option<String>,
     pub killswitch: Arc<AtomicBool>,
 }
 
@@ -46,6 +48,7 @@ impl PrivateIdService {
         input_with_headers: bool,
         na_val: Option<&str>,
         use_row_numbers: bool,
+        metrics_path: Option<String>,
     ) -> PrivateIdService {
         PrivateIdService {
             protocol: CompanyPrivateId::new(),
@@ -54,6 +57,7 @@ impl PrivateIdService {
             input_with_headers,
             na_val: na_val.map(String::from),
             use_row_numbers,
+            metrics_path,
             killswitch: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -234,6 +238,12 @@ impl PrivateId for PrivateIdService {
             .extra_label("reveal")
             .build();
         self.protocol.write_company_to_id_map();
+        let metrics_obj = metrics::Metrics::new(
+            "private-id".to_string(),
+            Some(self.protocol.get_e_company_size()),
+            Some(self.protocol.get_e_partner_size()),
+            Some(self.protocol.get_id_map_size()),
+        );
         match &self.output_path {
             Some(p) => {
                 if let Ok(output_path_s3) = S3Path::from_str(p) {
@@ -275,6 +285,27 @@ impl PrivateId for PrivateIdService {
             None => self
                 .protocol
                 .print_id_map(10, self.input_with_headers, self.use_row_numbers),
+        }
+        match &self.metrics_path {
+            Some(p) => {
+                if let Ok(metrics_path_s3) = S3Path::from_str(p) {
+                    let s3_tempfile = tempfile::NamedTempFile::new().unwrap();
+                    let (_file, path) = s3_tempfile.keep().unwrap();
+                    let path = path.to_str().expect("Failed to convert path to str");
+                    metrics_obj.save_metrics(&String::from(path))
+                        .expect("Failed to metrics to tempfile");
+                    metrics_path_s3
+                        .copy_from_local(&path)
+                        .await
+                        .expect("Failed to write to S3");
+                } else {
+                    metrics_obj.save_metrics(p)
+                        .expect("Failed to write to metrics path");
+                }
+            }
+            None => {
+                metrics_obj.print_metrics();
+            }
         }
         {
             debug!("Setting up flag for graceful down");

--- a/protocol-rpc/src/rpc/private-id/rpc_server/metrics.rs
+++ b/protocol-rpc/src/rpc/private-id/rpc_server/metrics.rs
@@ -1,0 +1,52 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+//  SPDX-License-Identifier: Apache-2.0
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::fs::File;
+
+#[derive(Serialize, Deserialize)]
+pub struct Metrics {
+    protocol_name: String,
+    partner_input_size: Option<usize>,
+    publisher_input_size: Option<usize>,
+    union_file_size: Option<usize>,
+}
+
+impl Metrics {
+    pub fn new(
+        protocol_name: String,
+        partner_input_size: Option<usize>,
+        publisher_input_size: Option<usize>,
+        union_file_size: Option<usize>,
+    ) -> Metrics {
+        Metrics {
+            protocol_name,
+            partner_input_size,
+            publisher_input_size,
+            union_file_size,
+        }
+    }
+
+    pub fn set_partner_input_size(&mut self, partner_input_size: usize) {
+        self.partner_input_size = Some(partner_input_size);
+    }
+
+    pub fn set_publisher_input_size(&mut self, publisher_input_size: usize) {
+        self.publisher_input_size = Some(publisher_input_size);
+    }
+
+    pub fn set_union_file_size(&mut self, union_file_size: usize) {
+        self.union_file_size = Some(union_file_size);
+    }
+
+    pub fn save_metrics(&self, path: &str) ->  Result<(), serde_json::Error> {
+        let f = &File::create(path).unwrap();
+        serde_json::to_writer(f, &self)
+    }
+
+    pub fn print_metrics(&self) {
+        println!("-----BEGIN METRIC VIEW-----");
+        println!("{}", serde_json::to_string(&self).unwrap());
+        println!("-----END METRIC VIEW-----");
+    }
+}

--- a/protocol-rpc/src/rpc/private-id/rpc_server/metrics.rs
+++ b/protocol-rpc/src/rpc/private-id/rpc_server/metrics.rs
@@ -1,25 +1,26 @@
 //  Copyright (c) Facebook, Inc. and its affiliates.
 //  SPDX-License-Identifier: Apache-2.0
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
 use serde_json;
 use std::fs::File;
 
 #[derive(Serialize, Deserialize)]
-pub struct Metrics {
+struct RawMetrics {
     protocol_name: String,
     partner_input_size: Option<usize>,
     publisher_input_size: Option<usize>,
     union_file_size: Option<usize>,
 }
 
-impl Metrics {
-    pub fn new(
+impl RawMetrics {
+    fn new(
         protocol_name: String,
         partner_input_size: Option<usize>,
         publisher_input_size: Option<usize>,
         union_file_size: Option<usize>,
-    ) -> Metrics {
-        Metrics {
+    ) -> RawMetrics {
+        RawMetrics {
             protocol_name,
             partner_input_size,
             publisher_input_size,
@@ -27,26 +28,71 @@ impl Metrics {
         }
     }
 
-    pub fn set_partner_input_size(&mut self, partner_input_size: usize) {
-        self.partner_input_size = Some(partner_input_size);
-    }
-
-    pub fn set_publisher_input_size(&mut self, publisher_input_size: usize) {
-        self.publisher_input_size = Some(publisher_input_size);
-    }
-
-    pub fn set_union_file_size(&mut self, union_file_size: usize) {
-        self.union_file_size = Some(union_file_size);
-    }
-
-    pub fn save_metrics(&self, path: &str) ->  Result<(), serde_json::Error> {
+    fn save_metrics(&self, path: &str) ->  Result<(), serde_json::Error> {
         let f = &File::create(path).unwrap();
         serde_json::to_writer(f, &self)
     }
 
-    pub fn print_metrics(&self) {
+    fn print_metrics(&self) {
         println!("-----BEGIN METRIC VIEW-----");
         println!("{}", serde_json::to_string(&self).unwrap());
         println!("-----END METRIC VIEW-----");
+    }
+}
+
+pub struct Metrics {
+    protocol_name: String,
+    partner_input_size: Arc<RwLock<Option<usize>>>,
+    publisher_input_size: Arc<RwLock<Option<usize>>>,
+    union_file_size: Arc<RwLock<Option<usize>>>,
+}
+
+impl Metrics {
+    pub fn new(protocol_name: String) -> Metrics {
+        Metrics {
+            protocol_name,
+            partner_input_size: Arc::new(RwLock::default()),
+            publisher_input_size: Arc::new(RwLock::default()),
+            union_file_size: Arc::new(RwLock::default()),
+        }
+    }
+
+    fn cp_to_raw(&self) -> RawMetrics{
+        RawMetrics::new(
+            self.protocol_name.clone(),
+            *self.partner_input_size.read().unwrap(),
+            *self.publisher_input_size.read().unwrap(),
+            *self.union_file_size.read().unwrap(),
+        )
+    }
+    pub fn set_partner_input_size(&self, partner_input_size: usize) {
+        let mut d = self.partner_input_size
+            .write()
+            .unwrap();
+        *d = Some(partner_input_size);
+    }
+
+    pub fn set_publisher_input_size(&self, publisher_input_size: usize) {
+        let mut d = self.publisher_input_size
+            .write()
+            .unwrap();
+        *d = Some(publisher_input_size);
+    }
+
+    pub fn set_union_file_size(&self, union_file_size: usize) {
+        let mut d = self.union_file_size
+            .write()
+            .unwrap();
+        *d = Some(union_file_size);
+    }
+
+    pub fn save_metrics(&self, path: &str) ->  Result<(), serde_json::Error> {
+        let raw = self.cp_to_raw();
+        raw.save_metrics(path)
+    }
+
+    pub fn print_metrics(&self) {
+        let raw = self.cp_to_raw();
+        raw.print_metrics();
     }
 }

--- a/protocol-rpc/src/rpc/private-id/server.rs
+++ b/protocol-rpc/src/rpc/private-id/server.rs
@@ -146,8 +146,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Input path: {}", input_path);
 
+    let mut metrics_path: Option<String> = None;
     if output_path.is_some() {
         info!("Output path: {}", output_path.unwrap());
+        metrics_path = Some(format!("{}_metrics", output_path.unwrap()));
     } else {
         info!("Output view to stdout (first 10 items)");
     }
@@ -158,6 +160,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         input_with_headers,
         na_val,
         use_row_numbers,
+        metrics_path,
     );
 
     let ks = service.killswitch.clone();

--- a/protocol/src/private_id/company.rs
+++ b/protocol/src/private_id/company.rs
@@ -79,6 +79,18 @@ impl CompanyPrivateId {
         }
         status
     }
+
+    pub fn get_e_company_size(&self) -> usize {
+        self.e_company.read().unwrap().len()
+    }
+
+    pub fn get_e_partner_size(&self) -> usize {
+        self.e_partner.read().unwrap().len()
+    }
+
+    pub fn get_id_map_size(&self) -> usize {
+        self.id_map.read().unwrap().len()
+    }
 }
 
 impl Default for CompanyPrivateId {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

In order to transfer metrics from PID to S3, we are enabling capability to output metrics into a file/S3/stdout.
[FB Only] Please see a [post](https://fb.workplace.com/groups/164332244998024/posts/753009439463632) for metric logging plan and a [doc](https://fburl.com/q1mwxdqy) for complete metric logging framework.

In this diff, we are newly logging four different fields(`protocol_name`, `partner_input_size`, `publisher_input_size`, `union_file_size`) on publisher size. To do that, we added `metrics_obj` as a member of `PrivateIdService` and added its logging into `reveal()` function.

## How Has This Been Tested (if it applies)
```
$ cargo build
$ cargo test
```
### Server-side
```
$ env RUST_LOG=info cargo run --bin private-id-server -- --host 0.0.0.0:10009 --input etc/example/email_company.csv --output ~/output.csv --tls-dir etc/example/dummy_certs
$ cat ~/output.csv_metrics
{"protocol_name":"private-id","partner_input_size":4,"publisher_input_size":5,"union_file_size":6}yshiraki@devvm5036:~/Private-ID(add-metric-logging)

$ env RUST_LOG=info cargo run --bin privenv RUST_LOG=info cargo run --bin private-id-server -- --host 0.0.0.0:10009 --input etc/example/email_company.csv --stdout --tls-dir etc/example/dummy_certs
-----BEGIN METRIC VIEW-----
{"protocol_name":"private-id","partner_input_size":4,"publisher_input_size":5,"union_file_size":6}
-----END METRIC VIEW-----
```

### Client-side
```
$ env RUST_LOG=info cargo run --bin private-id-client -- --company localhost:10009 --input etc/example/email_partner.csv --stdout --tls-dir etc/example/dummy_certs
```

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
