### PR TITLE
Make PID protocol metric output path configurable

### DIFF
--- a/protocol-rpc/src/rpc/private-id/server.rs
+++ b/protocol-rpc/src/rpc/private-id/server.rs
@@ -49,6 +49,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .short("o")
                 .takes_value(true)
                 .help("Path to output file, output format: private-id, option(key)"),
+            Arg::with_name("metric-path")
+                .long("metric-path")
+                .takes_value(true)
+                .help("Path to metric output file"),
             Arg::with_name("stdout")
                 .long("stdout")
                 .short("u")
@@ -125,6 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let input_with_headers = matches.is_present("input-with-headers");
     let output_path = matches.value_of("output");
+    let metric_path = matches.value_of("metric-path");
     let na_val = matches.value_of("not-matched-value");
     let use_row_numbers = matches.is_present("use-row-numbers");
 
@@ -146,10 +151,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Input path: {}", input_path);
 
-    let mut metrics_path: Option<String> = None;
+    let mut metrics_output_path: Option<String> = None;
+    if metric_path.is_some() {
+        metrics_output_path = Some(metric_path.unwrap().to_string());
+    }
+
     if output_path.is_some() {
         info!("Output path: {}", output_path.unwrap());
-        metrics_path = Some(format!("{}_metrics", output_path.unwrap()));
+        if metrics_output_path.is_none() {
+            metrics_output_path = Some(format!("{}_metrics", output_path.unwrap()));
+        }
     } else {
         info!("Output view to stdout (first 10 items)");
     }
@@ -160,7 +171,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         input_with_headers,
         na_val,
         use_row_numbers,
-        metrics_path,
+        metrics_output_path,
     );
 
     let ks = service.killswitch.clone();


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
This PR makes the metric output path specifiable while keeping the default metric output path the same. We can provide `--metric-path` to specify the location of the metric output file. 

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
The following [test](https://github.com/facebookresearch/Private-ID#private-id-1) was run locally with and without the newly added option `--metric-path` and the creation of the output metric file was confirmed.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] The documentation is up-to-date with the changes I made.
- [ x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
