### PR TITLE
Clean up tokio_rusttls as it's never used in TLS connection.

### DIFF
--- a/protocol-rpc/Cargo.toml
+++ b/protocol-rpc/Cargo.toml
@@ -74,7 +74,6 @@ env_logger = "0.7.1"
 tonic = {version="0.5.2", features=["tls", "tls-roots", "prost"]}
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "fs", "macros", "net"] }
 tokio-stream = { version =  "0.1.6", features = ["net"] }
-tokio-rustls = "0.22"
 tower = { version = "0.3.0" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0"

--- a/protocol-rpc/src/connect/create_client.rs
+++ b/protocol-rpc/src/connect/create_client.rs
@@ -7,7 +7,6 @@ extern crate crypto;
 extern crate ctrlc;
 extern crate protocol;
 extern crate retry;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use log::{error, info, warn};

--- a/protocol-rpc/src/connect/tls.rs
+++ b/protocol-rpc/src/connect/tls.rs
@@ -2,14 +2,13 @@
 //  SPDX-License-Identifier: Apache-2.0
 
 extern crate log;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use log::{debug, error, info};
 
 use futures::executor::block_on;
 use http::Uri;
-use std::{fs, io::BufReader, path::Path};
+use std::path::Path;
 use tonic::transport::{Certificate, Identity};
 use url::Url;
 
@@ -119,44 +118,6 @@ pub fn host_into_url(host: &str, no_tls: bool) -> Url {
     } else {
         pre
     }
-}
-
-/// Reads pem-format certificate from path
-/// Returns cert in byte-format usable for tonic
-pub fn load_tonic_pem_cert<T>(path: T) -> Vec<u8>
-where
-    T: AsRef<Path> + Copy,
-{
-    let rustls_cert = load_rustls_cert(path);
-    rustls_cert.0
-}
-
-/// Reads certificates from path,
-/// if there are multiple certs in the file (chain), reads them into vector
-/// returns rustls certificate within tokio_rustls package
-pub(crate) fn load_rustls_certs<T>(path: T) -> Vec<tokio_rustls::rustls::Certificate>
-where
-    T: AsRef<Path> + Copy,
-{
-    let certfile = fs::File::open(path)
-        .unwrap_or_else(|_| panic!("cannot open certificate file {}", path.as_ref().display()));
-    let mut reader = BufReader::new(certfile);
-    tokio_rustls::rustls::internal::pemfile::certs(&mut reader).unwrap()
-}
-
-/// Reads a single certificate from the file,
-/// will panic if the file contains more than one cert
-/// returns rustls certificate within tokio_rustls package
-pub(crate) fn load_rustls_cert<T>(path: T) -> tokio_rustls::rustls::Certificate
-where
-    T: AsRef<Path> + Copy,
-{
-    let r = load_rustls_certs(&path);
-    if r.len() != 1 {
-        error!("Path contains {} certs, expected 1", r.len());
-        panic!("Panic, due to improper input on load single cert");
-    }
-    r.get(0).unwrap().to_owned()
 }
 
 #[cfg(test)]

--- a/protocol-rpc/src/proto/streaming.rs
+++ b/protocol-rpc/src/proto/streaming.rs
@@ -4,7 +4,6 @@
 extern crate crypto;
 extern crate http;
 extern crate log;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use crypto::prelude::*;

--- a/protocol-rpc/src/rpc/private-id-multi-key/client.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/client.rs
@@ -8,7 +8,6 @@ extern crate ctrlc;
 extern crate protocol;
 extern crate retry;
 extern crate rpc;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use clap::{App, Arg, ArgGroup};

--- a/protocol-rpc/src/rpc/private-id/client.rs
+++ b/protocol-rpc/src/rpc/private-id/client.rs
@@ -8,7 +8,6 @@ extern crate ctrlc;
 extern crate protocol;
 extern crate retry;
 extern crate rpc;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use clap::{App, Arg, ArgGroup};

--- a/protocol-rpc/src/rpc/suid-create/client.rs
+++ b/protocol-rpc/src/rpc/suid-create/client.rs
@@ -8,7 +8,6 @@ extern crate ctrlc;
 extern crate protocol;
 extern crate retry;
 extern crate rpc;
-extern crate tokio_rustls;
 extern crate tonic;
 
 use clap::{App, Arg, ArgGroup};


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

When debugging TLS code in Private ID, we realize that the `tokio-rustls` library and the related functions are never used in current TLS code. This PR clean up the dependency

## How Has This Been Tested (if it applies)

```
cargo build
```

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
