### PR TITLE
Handle s3 file path in multi-key PID

### DIFF
--- a/protocol-rpc/src/rpc/private-id-multi-key/client.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/client.rs
@@ -16,7 +16,7 @@ use log::info;
 use std::convert::TryInto;
 use tonic::Request;
 
-use common::timer;
+use common::{gcs_path::GCSPath, s3_path::S3Path, timer};
 use crypto::prelude::TPayload;
 use protocol::private_id_multi_key::{partner::PartnerPrivateIdMultiKey, traits::*};
 use rpc::{
@@ -26,6 +26,7 @@ use rpc::{
         RpcClient,
     },
 };
+use std::str::FromStr;
 
 mod rpc_client;
 
@@ -113,7 +114,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_matches();
 
     let global_timer = timer::Timer::new_silent("global");
-    let input_path = matches.value_of("input").unwrap_or("input.csv");
+    let input_path_str = matches.value_of("input").unwrap_or("input.csv");
+    let mut input_path = input_path_str.to_string();
+    if let Ok(s3_path) = S3Path::from_str(input_path_str) {
+        info!(
+            "Reading {} from S3 and copying to local path",
+            input_path_str
+        );
+        let local_path = s3_path
+            .copy_to_local()
+            .await
+            .expect("Failed to copy s3 path to local tempfile");
+        info!("Wrote {} to tempfile {}", input_path_str, local_path);
+        input_path = local_path;
+    } else if let Ok(gcs_path) = GCSPath::from_str(input_path_str) {
+        info!(
+            "Reading {} from GCS and copying to local path",
+            input_path_str
+        );
+        let local_path = gcs_path
+            .copy_to_local()
+            .await
+            .expect("Failed to copy GCS path to local tempfile");
+        info!("Wrote {} to tempfile {}", input_path_str, local_path);
+        input_path = local_path;
+    }
     let input_with_headers = matches.is_present("input-with-headers");
     let output_path = matches.value_of("output");
 
@@ -330,7 +355,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 16. Create partner's ID spine and print
     partner_protocol.create_id_map(v_partner, s_prime_company);
     match output_path {
-        Some(p) => partner_protocol.save_id_map(&String::from(p)).unwrap(),
+        Some(p) => {
+            if let Ok(output_path_s3) = S3Path::from_str(p) {
+                let s3_tempfile = tempfile::NamedTempFile::new().unwrap();
+                let (_file, path) = s3_tempfile.keep().unwrap();
+                let path = path.to_str().expect("Failed to convert path to str");
+                partner_protocol
+                    .save_id_map(&String::from(path))
+                    .expect("Failed to save id map to tempfile");
+                output_path_s3
+                    .copy_from_local(&path)
+                    .await
+                    .expect("Failed to write to S3");
+            } else if let Ok(output_path_gcp) = GCSPath::from_str(p) {
+                let gcs_tempfile = tempfile::NamedTempFile::new().unwrap();
+                let (_file, path) = gcs_tempfile.keep().unwrap();
+                let path = path.to_str().expect("Failed to convert path to str");
+                partner_protocol
+                    .save_id_map(&String::from(path))
+                    .expect("Failed to save id map to tempfile");
+                output_path_gcp
+                    .copy_from_local(&path)
+                    .await
+                    .expect("Failed to write to GCS");
+            } else {
+                partner_protocol
+                    .save_id_map(&String::from(p))
+                    .expect("Failed to save id map to output file");
+            }
+        }
         None => partner_protocol.print_id_map(),
     }
 

--- a/protocol/src/private_id_multi_key/company.rs
+++ b/protocol/src/private_id_multi_key/company.rs
@@ -15,6 +15,7 @@ use crypto::{
 };
 
 use common::{
+    files,
     permutations::{gen_permute_pattern, permute, undo_permute},
     timer,
 };
@@ -260,7 +261,7 @@ impl CompanyPrivateIdMultiKeyProtocol for CompanyPrivateIdMultiKey {
                         let match_idx = e
                             .iter()
                             .map(|key|
-                                // TODO: Replace with match 
+                                // TODO: Replace with match
                                 if e_c_map.contains_key(&key.compress().to_bytes().to_vec()) {
                                     let &m_idx = e_c_map.get(&key.compress().to_bytes().to_vec()).unwrap();
                                     (m_idx, e_c_valid[m_idx])


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
In [the past PR](https://github.com/facebookresearch/Private-ID/pull/16), S3 file path handling was added to single-key PID protocol, but not yet added to multi-key protocol. We are replicating the logic to multi-key protocol.

## How Has This Been Tested (if it applies)
We tested together with the change on PCS in [the on-going PR](https://github.com/facebookresearch/fbpcs/pull/790).

### E2E test
```
$ buck run //measurement/private_lift:fbpcs_e2e_runner -- e2e "lift" "${USER}_$(date +%s)_" 1 --partner_config="/data/users/$USER/fbsource/fbcode/measurement/private_lift/platform/pl_coordinator/config_cloud_dev.yml" --thrift="dev"
```
Python log: P493863508

### Local test
```
$ env RUST_LOG=info cargo run --bin private-id-multi-key-server --     --host 0.0.0.0:10009     --input etc/example/private_id_multi_key/Ex1_company.csv     --stdout     --tls-dir etc/example/dummy_certs
```
```
$ env RUST_LOG=info cargo run --bin private-id-multi-key-client --      --company localhost:10009      --input etc/example/private_id_multi_key/Ex1_partner.csv      --stdout      --tls-dir etc/example/dummy_certs
```


<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
