### PR TITLE
Make PID multi-key protocol metric output path configurable

### DIFF
--- a/protocol-rpc/src/rpc/private-id-multi-key/rpc_server.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/rpc_server.rs
@@ -18,7 +18,7 @@ use std::{
     },
 };
 use tonic::{Code, Request, Response, Status, Streaming};
-
+mod metrics;
 use common::{gcs_path::GCSPath, s3_path::S3Path, timer};
 use protocol::private_id_multi_key::{
     company::CompanyPrivateIdMultiKey, traits::CompanyPrivateIdMultiKeyProtocol,
@@ -38,6 +38,8 @@ pub struct PrivateIdMultiKeyService {
     input_path: String,
     output_path: Option<String>,
     input_with_headers: bool,
+    metrics_path: Option<String>,
+    metrics_obj: metrics::Metrics,
     pub killswitch: Arc<AtomicBool>,
 }
 
@@ -46,12 +48,17 @@ impl PrivateIdMultiKeyService {
         input_path: &str,
         output_path: Option<&str>,
         input_with_headers: bool,
+        metrics_path: Option<String>,
     ) -> PrivateIdMultiKeyService {
         PrivateIdMultiKeyService {
             protocol: CompanyPrivateIdMultiKey::new(),
             input_path: String::from(input_path),
             output_path: output_path.map(String::from),
             input_with_headers,
+            metrics_path,
+            metrics_obj: metrics::Metrics::new(
+                "private-id-multi-key".to_string(),
+            ),
             killswitch: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -278,6 +285,9 @@ impl PrivateIdMultiKey for PrivateIdMultiKeyService {
             .extra_label("reveal")
             .build();
         self.protocol.write_company_to_id_map();
+        self.metrics_obj.set_partner_input_size(self.protocol.get_e_partner_size());
+        self.metrics_obj.set_publisher_input_size(self.protocol.get_e_company_size());
+        self.metrics_obj.set_union_file_size(self.protocol.get_id_map_size());
         match &self.output_path {
             Some(p) => {
                 if let Ok(output_path_s3) = S3Path::from_str(p) {
@@ -313,6 +323,27 @@ impl PrivateIdMultiKey for PrivateIdMultiKeyService {
                 }
             }
             None => self.protocol.print_id_map(),
+        }
+        match &self.metrics_path {
+            Some(p) => {
+                if let Ok(metrics_path_s3) = S3Path::from_str(p) {
+                    let s3_tempfile = tempfile::NamedTempFile::new().unwrap();
+                    let (_file, path) = s3_tempfile.keep().unwrap();
+                    let path = path.to_str().expect("Failed to convert path to str");
+                    self.metrics_obj.save_metrics(&String::from(path))
+                        .expect("Failed to metrics to tempfile");
+                    metrics_path_s3
+                        .copy_from_local(&path)
+                        .await
+                        .expect("Failed to write to S3");
+                } else {
+                    self.metrics_obj.save_metrics(p)
+                        .expect("Failed to write to metrics path");
+                }
+            }
+            None => {
+                self.metrics_obj.print_metrics();
+            }
         }
         {
             debug!("Setting up flag for graceful down");

--- a/protocol-rpc/src/rpc/private-id-multi-key/server.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/server.rs
@@ -52,6 +52,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .short("o")
                 .takes_value(true)
                 .help("Path to output file, output format: private-id, option(key)"),
+            Arg::with_name("metric-path")
+                .long("metric-path")
+                .takes_value(true)
+                .help("Path to metric output file"),
             Arg::with_name("stdout")
                 .long("stdout")
                 .short("u")
@@ -120,6 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let input_with_headers = matches.is_present("input-with-headers");
     let output_path = matches.value_of("output");
+    let metric_path = matches.value_of("metric-path");
 
     let no_tls = matches.is_present("no-tls");
     let host = matches.value_of("host");
@@ -139,6 +144,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Input path: {}", input_path);
 
+    let mut metrics_output_path: Option<String> = None;
+    if metric_path.is_some() {
+        metrics_output_path = Some(metric_path.unwrap().to_string());
+        if metrics_output_path.is_none() {
+            metrics_output_path = Some(format!("{}_metrics", output_path.unwrap()));
+        }
+    }
+
     if output_path.is_some() {
         info!("Output path: {}", output_path.unwrap());
     } else {
@@ -146,7 +159,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let service =
-        rpc_server::PrivateIdMultiKeyService::new(&input_path, output_path, input_with_headers);
+        rpc_server::PrivateIdMultiKeyService::new(&input_path, output_path, input_with_headers, metrics_output_path);
 
     let ks = service.killswitch.clone();
     let recv_thread = thread::spawn(move || {

--- a/protocol/src/private_id_multi_key/company.rs
+++ b/protocol/src/private_id_multi_key/company.rs
@@ -69,6 +69,18 @@ impl CompanyPrivateIdMultiKey {
     pub fn load_data(&self, path: &str, input_with_headers: bool) {
         load_data(self.plaintext.clone(), path, input_with_headers);
     }
+
+    pub fn get_e_company_size(&self) -> usize {
+        self.e_company.read().unwrap().len()
+    }
+
+    pub fn get_e_partner_size(&self) -> usize {
+        self.e_partner.read().unwrap().len()
+    }
+
+    pub fn get_id_map_size(&self) -> usize {
+        self.id_map.read().unwrap().len()
+    }
 }
 
 impl Default for CompanyPrivateIdMultiKey {
@@ -491,5 +503,27 @@ impl CompanyPrivateIdMultiKeyProtocol for CompanyPrivateIdMultiKey {
                 "Unable to write partner view to file".to_string(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_get_e_company_size() {
+        let b = CompanyPrivateIdMultiKey::new();
+        assert_eq!(b.get_e_company_size(), 0);
+    }
+
+    #[test]
+    fn test_get_e_partner_size() {
+        let b = CompanyPrivateIdMultiKey::new();
+        assert_eq!(b.get_e_partner_size(), 0);
+    }
+
+    #[test]
+    fn test_get_id_map_size() {
+        let b = CompanyPrivateIdMultiKey::new();
+        assert_eq!(b.get_id_map_size(), 0);
     }
 }


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
Make PID multi-key protocol metric output path configurable

## How Has This Been Tested (if it applies)
1. stdout
Server:
env RUST_LOG=info cargo run --bin private-id-multi-key-server -- --host 0.0.0.0:10009 --input etc/example/email_company.csv --tls-dir etc/example/dummy_certs --stdout
Client:
 env RUST_LOG=info cargo run --bin private-id-multi-key-client -- \
--company localhost:10009 \
--input etc/example/email_partner.csv \
--stdout \
--tls-dir etc/example/dummy_certs

result:
<img width="1252" alt="Screen Shot 2022-05-03 at 1 54 36 PM" src="https://user-images.githubusercontent.com/26918282/166564202-6bf0cda1-f73f-4d4b-8182-ed7f86435b74.png">

2. With output-path

server:
env RUST_LOG=info cargo run --bin private-id-multi-key-server -- --host 0.0.0.0:10009 --input etc/example/email_company.csv --tls-dir etc/example/dummy_certs --output ~/pid_output.csv

client:
 env RUST_LOG=info cargo run --bin private-id-multi-key-client -- \
--company localhost:10009 \
--input etc/example/email_partner.csv \
--stdout \
--tls-dir etc/example/dummy_certs

result:
<img width="858" alt="Screen Shot 2022-05-03 at 1 58 41 PM" src="https://user-images.githubusercontent.com/26918282/166565169-8046cb76-f0f5-477b-b869-359ac9326518.png">


3. With metric-path
server:
env RUST_LOG=info cargo run --bin private-id-multi-key-server -- --host 0.0.0.0:10009 --input etc/example/email_company.csv --tls-dir etc/example/dummy_certs --stdout --metric-path ~/pid_metrics.csv

client:
 env RUST_LOG=info cargo run --bin private-id-multi-key-client -- \
--company localhost:10009 \
--input etc/example/email_partner.csv \
--stdout \
--tls-dir etc/example/dummy_certs

result:
<img width="1250" alt="Screen Shot 2022-05-03 at 1 26 57 PM" src="https://user-images.githubusercontent.com/26918282/166560281-c48504ed-1ba7-44a6-a6ce-0d729c2b826c.png">

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
