### PR TITLE
generate_cert script double quote lint issue

### DIFF
--- a/etc/example/generate_cert.sh
+++ b/etc/example/generate_cert.sh
@@ -3,8 +3,8 @@
 set -e
 
 directory="$( dirname -- "$0";)/dummy_certs";
-mkdir $directory || exit
-cd $directory || exit
+mkdir "$directory" || exit
+cd "$directory" || exit
 
 # Create cnf file. DNS name is VERY important
 tee ssl-extensions-x509.cnf << EOF


### PR DESCRIPTION
Summary: add double quote to variable

Differential Revision: D37337189

