### PR TITLE
Upgrade the rand lib from rand0.7 to ran 0.8

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.7.1"
 rayon = "1.3.0"
 clap = "2.33.0"
 csv = "1.1.1"
-rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+rand = { version = "0.8", features = ["small_rng"] }
 indicatif = "0.13.0"
 hex = "0.3.0"
 serde = {version = "1.0.104", features = ["derive"] }

--- a/common/datagen/datagen.rs
+++ b/common/datagen/datagen.rs
@@ -65,6 +65,7 @@ pub mod gen {
         thread_rng()
             .sample_iter(&distributions::Alphanumeric)
             .take(size)
+            .map(char::from)
             .collect()
     }
 

--- a/common/src/permutations.rs
+++ b/common/src/permutations.rs
@@ -15,7 +15,7 @@ pub fn gen_permute_pattern(n: usize) -> Vec<usize> {
 
     // To shuffle an array a of n elements (indices 0..n-1):
     for i in 0..n - 1 {
-        let j = rng_.gen_range(i, n);
+        let j = rng_.gen_range(i..n);
         res_.swap(i, j);
     }
     res_


### PR DESCRIPTION
Summary:
This is the to-do list when we migrate from github to fbcode. In order to migrate fast, we did not keep the lib version same as the internal version.

rand07 in the internal rust lib is temporary and can be removed in the future. We need to update the lib to rand 0.8 in rust to avoid build error when rand07 is removed.

{F753610665} {F753610678}

Reviewed By: rajprateek

Differential Revision: D37937653

