### PR TITLE
Prevent panicking each time the computed sum is zero

### DIFF
--- a/protocol/src/pjc/partner.rs
+++ b/protocol/src/pjc/partner.rs
@@ -8,6 +8,7 @@ use common::timer;
 
 use num_bigint::BigUint;
 use num_traits::One;
+use num_traits::Zero;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -173,9 +174,13 @@ impl PartnerPJCProtocol for PartnerPjc {
                 assert_eq!(encrypted_sum.len(), 1);
                 let z = ((self.he_cipher.decrypt_vec(encrypted_sum))[0]).clone();
                 let sum = {
-                    let v = (z % &max_val).to_u64_digits();
-                    assert_eq!(v.len(), 1);
-                    v[0]
+                    if z.is_zero() {
+                        0
+                    } else {   
+                        let v = (z % &max_val).to_u64_digits();
+                        assert_eq!(v.len(), 1);
+                        v[0]
+                    }
                 };
                 info!("Feature: {},  Sum {}", feature_index, sum);
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
In Private Join and Compute, a sum of features equal to zero (like for instance if the intersection is empty) made the code panicking because of `BigUint::to_u64_digits` returning an empty vec when converting a BigUint::Zero.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
