### PR TITLE
Kick off github CI job when exporting diff to github

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: Build private-id Docker Image
+
+on:
+  pull_request:
+    branches: [ main ]
+env:
+  DISTRO: ubuntu
+  REGISTRY: ghcr.io
+  LOCAL_IMAGE_NAME: private-id
+  LOCAL_IMAGE_TAG: latest
+  REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  push:
+   runs-on: ubuntu-latest
+   name: Build image
+   permissions:
+    contents: read
+    packages: write
+
+   steps:
+
+     - name: Lowercase REGISTRY_IMAGE_NAME
+       id: string
+       uses: ASzc/change-string-case-action@v1
+       with:
+          string: ${{ env.REGISTRY_IMAGE_NAME }}
+     - run: |
+          echo "REGISTRY_IMAGE_NAME_LOWERCASE=${{ steps.string.outputs.lowercase }}" >> ${GITHUB_ENV}
+
+     - name: Check REGISTRY_IMAGE_NAME_LOWERCASE
+       run: |
+         echo "env.$REGISTRY_IMAGE_NAME_LOWERCASE"
+
+     - uses: actions/checkout@v2
+
+     - name: Build image
+       run: |
+        docker build -f ./Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,6 @@ name: Publish private-id Docker Image
 on:
   push:
     branches: [ main ]
-
 env:
   DISTRO: ubuntu
   REGISTRY: ghcr.io
@@ -20,7 +19,7 @@ jobs:
     packages: write
 
    steps:
-     
+
      - name: Lowercase REGISTRY_IMAGE_NAME
        id: string
        uses: ASzc/change-string-case-action@v1
@@ -28,17 +27,17 @@ jobs:
           string: ${{ env.REGISTRY_IMAGE_NAME }}
      - run: |
           echo "REGISTRY_IMAGE_NAME_LOWERCASE=${{ steps.string.outputs.lowercase }}" >> ${GITHUB_ENV}
-          
-     - name: Check REGISTRY_IMAGE_NAME_LOWERCASE 
+
+     - name: Check REGISTRY_IMAGE_NAME_LOWERCASE
        run: |
          echo "env.$REGISTRY_IMAGE_NAME_LOWERCASE"
-         
+
      - uses: actions/checkout@v2
-     
+
      - name: Build image
        run: |
         docker build -f ./Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} .
-    
+
     # Tests can be added here
 
      - name: Log into registry ${{ env.REGISTRY }}
@@ -57,7 +56,7 @@ jobs:
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.vars.outputs.ref }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:latest
-     
+
      - name: Push image to registry
        run: |
           docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM rust:latest AS build
 LABEL maintainer="Vlad Vlaskin <vladvlaskin@fb.com>"
 
 ENV BASE /usr/local
-
+RUN apt-get update && \
+    apt-get install -y cmake
 RUN rustup install stable && \
 rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 


### PR DESCRIPTION
Summary: Kick off github CI job when exporting diff to github

Reviewed By: rajprateek

Differential Revision: D38106985

