### PR TITLE
Add codec feature in toml file to fix the build error

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,5 +31,5 @@ tempfile = "3.2.0"
 thiserror = "1.0.25"
 tokio = { version = "1", features = ["full"] }
 cloud-storage = "0.10"
-tokio-util = "0.6.9"
+tokio-util = { version = "0.6.9", features = ["codec"] }
 serde_json = "1.0"


### PR DESCRIPTION
Summary:
Since the diff D37995341 (https://github.com/facebookresearch/Private-ID/commit/f5bd1faf768d88cc1e021205c836a2624727404a) failed on building on mac(outside failed internal passed).
add codec feature to run build successfully.

see the commit in github:
https://github.com/facebookresearch/Private-ID/actions/runs/2722925168

Reviewed By: rajprateek

Differential Revision: D38107033

