### PR TITLE
Codemod away ::{self};

### DIFF
--- a/common/src/metrics.rs
+++ b/common/src/metrics.rs
@@ -2,7 +2,6 @@
 //  SPDX-License-Identifier: Apache-2.0
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json;
 use std::fs::File;
 use std::sync::Arc;
 use std::sync::RwLock;


### PR DESCRIPTION
Summary: Previous codemod left some crust. This commit cleans up useless uses to use less uses.

Reviewed By: stepancheg

Differential Revision: D38211793

