### PR TITLE
Add run_id to PID binaries.

### DIFF
--- a/protocol-rpc/src/rpc/private-id-multi-key/client.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/client.rs
@@ -95,6 +95,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-domain")
                 .takes_value(true)
                 .help("Override TLS domain for SSL cert (if host is IP)"),
+            Arg::with_name("run_id")
+                .takes_value(true)
+                .long("run_id")
+                .default_value("")
+                .help("A run_id used to identify all the logs in a PL/PA run."),
         ])
         .groups(&[
             ArgGroup::with_name("tls")

--- a/protocol-rpc/src/rpc/private-id-multi-key/server.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/server.rs
@@ -94,6 +94,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .requires("tls-key")
                 .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
+            Arg::with_name("run_id")
+                .takes_value(true)
+                .long("run_id")
+                .default_value("")
+                .help("A run_id used to identify all the logs in a PL/PA run."),
         ])
         .groups(&[
             ArgGroup::with_name("tls")

--- a/protocol-rpc/src/rpc/private-id/client.rs
+++ b/protocol-rpc/src/rpc/private-id/client.rs
@@ -99,6 +99,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("not-matched-value")
                 .takes_value(true)
                 .help("Override the default placeholder value for non-matched records"),
+            Arg::with_name("run_id")
+                .takes_value(true)
+                .long("run_id")
+                .default_value("")
+                .help("A run_id used to identify all the logs in a PL/PA run."),
             Arg::with_name("use-row-numbers")
                 .long("use-row-numbers")
                 .takes_value(false)

--- a/protocol-rpc/src/rpc/private-id/server.rs
+++ b/protocol-rpc/src/rpc/private-id/server.rs
@@ -98,6 +98,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("not-matched-value")
                 .takes_value(true)
                 .help("Override the default placeholder value for non-matched records"),
+            Arg::with_name("run_id")
+                .takes_value(true)
+                .long("run_id")
+                .default_value("")
+                .help("A run_id used to identify all the logs in a PL/PA run."),
             Arg::with_name("use-row-numbers")
                 .long("use-row-numbers")
                 .takes_value(false)


### PR DESCRIPTION
Summary:
# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002

# This diff
Add run_id to PID binaries.

Differential Revision: D38726020

