### PR TITLE
Add unit test for load_data(), get_size() and ermute_hash_to_bytes() in private_id_multi_key

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -25,3 +25,4 @@ rayon = "1.3.0"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
 zeroize = "1.5.5"
+tempfile = "3.2.0"


### PR DESCRIPTION
Summary:
## What is this stack?
To improve PID rust code coverage from 50% to 75%, add unit tests for protocol private_id_multi_key.

Differential Revision: D38766385

