### PR TITLE
Add unit test for encrypt_permute on partner side

### DIFF
--- a/protocol/src/private_id_multi_key/partner.rs
+++ b/protocol/src/private_id_multi_key/partner.rs
@@ -530,4 +530,44 @@ mod tests {
         ];
         assert_eq!(actual_result, expected_result);
     }
+    #[test]
+    fn check_encrypt_permute() {
+        let f = create_data_file().unwrap();
+        let mut patner = PartnerPrivateIdMultiKey::new();
+        let p = f.path().to_str().unwrap();
+        patner.load_data(p, false).unwrap();
+        patner.self_permutation = Arc::new(RwLock::new(vec![2, 0, 1]));
+
+        let data = vec![
+            ByteBuffer {
+                buffer: vec![
+                    200, 135, 56, 19, 5, 207, 16, 147, 198, 229, 224, 111, 97, 119, 247, 238, 48,
+                    209, 55, 188, 30, 178, 53, 4, 110, 27, 182, 220, 156, 57, 53, 63,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    102, 237, 233, 208, 207, 235, 165, 5, 177, 27, 168, 233, 239, 69, 163, 80, 155,
+                    2, 85, 192, 182, 25, 20, 189, 118, 5, 225, 153, 13, 254, 201, 40,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    48, 54, 39, 197, 69, 34, 214, 167, 225, 117, 64, 223, 51, 164, 33, 208, 18,
+                    108, 38, 248, 215, 189, 94, 180, 82, 105, 196, 43, 189, 2, 220, 6,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    228, 188, 46, 30, 21, 100, 156, 96, 162, 185, 103, 149, 89, 159, 81, 67, 119,
+                    112, 0, 174, 99, 188, 74, 7, 13, 236, 98, 48, 50, 145, 156, 50,
+                ],
+            },
+        ];
+
+        let psum = vec![0, 2, 3, 4];
+        patner.private_keys.0 = create_key();
+        let res = patner.encrypt_permute(data, psum).unwrap();
+        assert_eq!(res.len(), 10);
+    }
 }


### PR DESCRIPTION
Summary:
# What
* Add unit tests for encrypt_permute on partner side
* TPayload is Vec<ByteBuffer> which  is the return value of encrypt_permute
* encrypt_permute function uses self_permutation, private_keys.0, data(TPayload) and psum(Vec<usize>).
* Verify TPayload length is correct or not

# Why
* need to improve code coverage

Reviewed By: wenqingren

Differential Revision: D39680932

