### PR TITLE
Add version tagging to PID repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,24 @@ jobs:
        run: |
         docker build -f ./Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} .
 
+     - name: Create version string
+       id: create_version
+       uses: paulhatch/semantic-version@v4.0.2
+       with:
+          tag_prefix: "v"
+          major_pattern: "((MAJOR))"
+          minor_pattern: "((MINOR))"
+          format: "${major}.${minor}.${patch}-pre${increment}"
+
+     - name: Add tag to commit
+       id: tag_version
+       uses: mathieudutour/github-tag-action@v6.0
+       with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.create_version.outputs.version_tag }}
+          tag_prefix: ""
+
+
     # Tests can be added here
 
      - name: Log into registry ${{ env.REGISTRY }}
@@ -56,7 +74,19 @@ jobs:
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.vars.outputs.ref }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:latest
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}.${{ steps.create_version.outputs.patch }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
 
      - name: Push image to registry
        run: |
           docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}
+
+     - name: Create release
+       uses: "actions/create-release@v1"
+       env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       with:
+          release_name: ${{ steps.create_version.outputs.version_tag }}
+          tag_name: ${{ steps.create_version.outputs.version_tag }}


### PR DESCRIPTION
Summary:
# What
* Publish specific `major.minor.patch` for PID repo
# Why
* We are making preparations to pin the FBPID version in the FBPCS repository and build. As part of this, we want the ability to pin at not only the patch version, but even at the minor or major version.

Differential Revision: D40038384

