### PR TITLE
Add unit test for hash and hash_encrypt_to_bytes for ecristrettosequential

### DIFF
--- a/common/src/files.rs
+++ b/common/src/files.rs
@@ -343,4 +343,15 @@ mod test {
         drop(file1);
         assert_eq!(buf, "11,12,13\n21,22,23\n");
     }
+
+    #[test]
+    fn test_write_vec_to_stdout() {
+        let s1 = vec![String::from("3"), String::from("a")];
+        let s2 = vec![String::from("2"), String::from("a")];
+        let s3 = vec![String::from("1"), String::from("a")];
+        let mut id_map = vec![s1, s2, s3];
+        let res = write_vec_to_stdout(&id_map, 4, false, false);
+
+        assert!(res.is_ok());
+    }
 }

--- a/common/src/metrics.rs
+++ b/common/src/metrics.rs
@@ -182,6 +182,7 @@ mod tests {
 
         let mut file = NamedTempFile::new().unwrap();
         m.save_metrics(file.path().to_str().unwrap()).unwrap();
+        m.print_metrics();
         let mut buf = String::new();
         file.read_to_string(&mut buf).unwrap();
         assert_eq!(

--- a/crypto/src/eccipher.rs
+++ b/crypto/src/eccipher.rs
@@ -450,4 +450,27 @@ mod tests {
             "The ECRistrettoSequential is: Ristretto EC ops sequential implementation"
         );
     }
+
+    #[test]
+    fn test_ecristrettosequential_hash() {
+        let parr = ECRistrettoSequential::default();
+        let input = &mut [String::from("3"), String::from("2")];
+
+        let res = parr.hash(input);
+        assert_eq!(res.len(), 2);
+    }
+
+    #[test]
+    fn test_ecristrettosequential_hash_encrypt_to_bytes() {
+        let mut rng = OsRng;
+        let parr = ECRistrettoSequential::default();
+        let input = &mut [String::from("3"), String::from("2")];
+        let key = {
+            let mut scalar_bytes = [0u8; 64];
+            rng.fill_bytes(&mut scalar_bytes);
+            Scalar::from_bytes_mod_order_wide(&scalar_bytes)
+        };
+        let res = parr.hash_encrypt_to_bytes(input, &key);
+        assert_eq!(res.len(), 2);
+    }
 }

--- a/protocol/src/private_id_multi_key/company.rs
+++ b/protocol/src/private_id_multi_key/company.rs
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn check_set_set_diff_output() {
         let f = create_data_file().unwrap();
-        let company = CompanyPrivateIdMultiKey::new();
+        let company = CompanyPrivateIdMultiKey::default();
         let p = f.path().to_str().unwrap();
         company.load_data(p, false);
 
@@ -720,10 +720,6 @@ mod tests {
             .w_company
             .read()
             .map(|data| data.to_vec())
-            .map_err(|err| {
-                error!("Unable to get w_company: {}", err);
-                ProtocolError::ErrorDeserialization("cannot obtain w_company".to_string())
-            })
             .ok()
             .unwrap();
         assert_eq!(res, data);
@@ -735,10 +731,6 @@ mod tests {
             .s_prime_partner
             .read()
             .map(|data| data.to_vec())
-            .map_err(|err| {
-                error!("Unable to get s_prime_partner: {}", err);
-                ProtocolError::ErrorDeserialization("cannot obtain s_prime_partner".to_string())
-            })
             .ok()
             .unwrap();
         assert_eq!(res, data);


### PR DESCRIPTION
Summary:
# What
* Add unit test for hash and hash_encrypt_to_bytes for ecristrettosequential
* For hash(), input is the slice of string
* For hash_encrypt_to_bytes, input is the slice of string and random key.
* check the size of array is equal or not

# Why
* need to improve code coverage

Differential Revision: D40079927

