### PR TITLE
Add unit test for write_vec_to_stdout and print_metrics

### DIFF
--- a/common/src/files.rs
+++ b/common/src/files.rs
@@ -343,4 +343,15 @@ mod test {
         drop(file1);
         assert_eq!(buf, "11,12,13\n21,22,23\n");
     }
+
+    #[test]
+    fn test_write_vec_to_stdout() {
+        let s1 = vec![String::from("3"), String::from("a")];
+        let s2 = vec![String::from("2"), String::from("a")];
+        let s3 = vec![String::from("1"), String::from("a")];
+        let id_map = vec![s1, s2, s3];
+        let res = write_vec_to_stdout(&id_map, 4, false, false);
+
+        assert!(res.is_ok());
+    }
 }

--- a/common/src/metrics.rs
+++ b/common/src/metrics.rs
@@ -182,6 +182,7 @@ mod tests {
 
         let mut file = NamedTempFile::new().unwrap();
         m.save_metrics(file.path().to_str().unwrap()).unwrap();
+        m.print_metrics();
         let mut buf = String::new();
         file.read_to_string(&mut buf).unwrap();
         assert_eq!(

--- a/protocol/src/private_id_multi_key/company.rs
+++ b/protocol/src/private_id_multi_key/company.rs
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn check_set_set_diff_output() {
         let f = create_data_file().unwrap();
-        let company = CompanyPrivateIdMultiKey::new();
+        let company = CompanyPrivateIdMultiKey::default();
         let p = f.path().to_str().unwrap();
         company.load_data(p, false);
 
@@ -720,10 +720,6 @@ mod tests {
             .w_company
             .read()
             .map(|data| data.to_vec())
-            .map_err(|err| {
-                error!("Unable to get w_company: {}", err);
-                ProtocolError::ErrorDeserialization("cannot obtain w_company".to_string())
-            })
             .ok()
             .unwrap();
         assert_eq!(res, data);
@@ -735,10 +731,6 @@ mod tests {
             .s_prime_partner
             .read()
             .map(|data| data.to_vec())
-            .map_err(|err| {
-                error!("Unable to get s_prime_partner: {}", err);
-                ProtocolError::ErrorDeserialization("cannot obtain s_prime_partner".to_string())
-            })
             .ok()
             .unwrap();
         assert_eq!(res, data);


### PR DESCRIPTION
Summary:
# What
* Add unit tests for write_vec_to_stdout and print_metrics
* run the write_vec_to_stdout with vector of strings
* check the response is okay or not
* For print_metrics() just run it.

# Why
* need to improve code coverage

Reviewed By: wenqingren

Differential Revision: D40078274

