### PR TITLE
Guard version tagging with conditionals to avoid invalid docker tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
    runs-on: ubuntu-latest
    name: Build and publish image
    permissions:
-    contents: read
+    contents: write
     packages: write
 
    steps:
@@ -74,10 +74,20 @@ jobs:
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.vars.outputs.ref }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:latest
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}.${{ steps.create_version.outputs.patch }}
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.create_version.outputs.version_tag }}
+
+     # Can't create a docker tag of just `0` or `0.0` or `0.0.0`
+     - name: Tag docker major version
+       if: steps.create_version.outputs.major != 0
+       run: docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.create_version.outputs.major }}
+
+     - name: Tag docker major.minor version
+       if: steps.create_version.outputs.major != 0 || steps.create_version.outputs.minor != 0
+       run: docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}
+
+     - name: Tag docker major.minor.patch version
+       if: steps.create_version.outputs.major != 0 || steps.create_version.outputs.minor != 0 || steps.create_version.outputs.patch != 0
+       run: docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME_LOWERCASE }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}.${{ steps.create_version.outputs.patch }}
 
      - name: Push image to registry
        run: |


### PR DESCRIPTION
Summary:
# What
* Title - don't allow a push of `0` or `0.0` or `0.0.0` in version tagging
* There was *probably* a way to use unix conditional short-circuiting to avoid separating these, but this felt easier to reason about than `[[ major != 0]] && docker tag`
# Why
* Those tags aren't valid docker tags (need an identifier >0 for versions)

Differential Revision: D40267079

