### PR TITLE
Add unit test for datagen, timer and create_client

### DIFF
--- a/common/datagen/datagen.rs
+++ b/common/datagen/datagen.rs
@@ -186,4 +186,15 @@ mod test {
         let res = gen::write_slice_to_file(input, 1, p);
         assert!(res.is_ok());
     }
+
+    #[test]
+    fn test_random_data() {
+        let size = 10;
+        let intrsct = size / 2;
+        let size_player = size - intrsct;
+
+        let data = gen::random_data(size_player, size_player, intrsct);
+
+        assert_eq!(data.player_a.len(), 10);
+    }
 }

--- a/common/src/timer.rs
+++ b/common/src/timer.rs
@@ -279,4 +279,37 @@ mod tests {
                 .build();
         }
     }
+
+    #[test]
+    fn test_qps() {
+        let t = Builder::new()
+            .label("foo")
+            .extra_label("bar")
+            .size(199)
+            .build();
+        t.qps("test", 10);
+    }
+
+    #[test]
+    fn test_silent() {
+        let t = Builder::default()
+            .label("foo")
+            .silent(true)
+            .extra_label("bar")
+            .size(199)
+            .build();
+        assert!(t.silent);
+    }
+
+    #[test]
+    fn test_elapsed_str() {
+        let t = Builder::new()
+            .label("foo")
+            .silent(true)
+            .extra_label("bar")
+            .size(199)
+            .build();
+        t.elapsed_str(Some("1"));
+        t.elapsed_log(Some("1"));
+    }
 }

--- a/protocol-rpc/src/connect/create_client.rs
+++ b/protocol-rpc/src/connect/create_client.rs
@@ -153,3 +153,32 @@ pub fn create_client(
 
     context
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_create_client_tls_panic() {
+        let no_tls = false;
+
+        let host_pre: Option<&str> = Some("localhost:10009");
+        let tls_dir = None;
+        let tls_key = None;
+        let tls_cert = None;
+        let tls_ca = None;
+        let tls_domain = None;
+
+        let _ = create_client(
+            no_tls,
+            host_pre,
+            tls_dir,
+            tls_key,
+            tls_cert,
+            tls_ca,
+            tls_domain,
+            "private-id-multi-key".to_string(),
+        );
+    }
+}


### PR DESCRIPTION
Summary:
# What
* Add unit test for create_client when tls information not given, should panic.
* Add unit test for timer. qps, silent and elapsed_str function
* Add unit test for random_data. check the length of result

# Why
* need to improve code coverage

Reviewed By: wenqingren

Differential Revision: D40491828

