### PR TITLE
Add unit test for paillier and fileio

### DIFF
--- a/common/src/files.rs
+++ b/common/src/files.rs
@@ -258,7 +258,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Got empty rows to print out")]
+    #[should_panic]
     fn test_sort_stringify_id_map_empty_row() {
         let s1 = vec![String::from("3"), String::from("a")];
         let s2 = vec![];

--- a/crypto/src/paillier.rs
+++ b/crypto/src/paillier.rs
@@ -666,4 +666,31 @@ mod tests {
             .count();
         assert_eq!(matching, x.len());
     }
+
+    #[test]
+    fn check_decrypt() {
+        use crate::paillier::decrypt;
+        let mut rng = rand::thread_rng();
+        let (m_e, m_d) = gen_keypair(2048_u64);
+        let e_key = gen_encryption_key(m_e);
+        let d_key = gen_decryption_key(m_d);
+
+        for _ in 0..1000 {
+            let msg = rng.gen_biguint_range(&BigUint::zero(), &e_key.n);
+            let cipher = encrypt(msg.clone(), &e_key);
+            assert!(msg == decrypt(cipher, &d_key));
+        }
+    }
+
+    #[test]
+    fn check_enc_serialise() {
+        let vals: Vec<BigUint> = vec![
+            BigUint::parse_bytes(b"1234", 10).unwrap(),
+            BigUint::parse_bytes(b"1234", 10).unwrap(),
+        ];
+        let cipher = PaillierParallel::default();
+
+        let x = cipher.enc_serialise(vals.as_ref());
+        assert_eq!(x.len(), 2);
+    }
 }

--- a/protocol/src/fileio.rs
+++ b/protocol/src/fileio.rs
@@ -222,4 +222,35 @@ mod tests {
         );
         assert_eq!(v_empty_cols, vec![String::from("e")]);
     }
+
+    #[test]
+    fn test_load_data_with_features() {
+        let self_num_records = Arc::new(RwLock::default());
+        let self_num_features = Arc::new(RwLock::default());
+        let plaintext_features = Arc::new(RwLock::default());
+        let plaintext_keys = Arc::new(RwLock::default());
+
+        let data = "email1,0 \n
+        phone2, 1\n
+        email3, 0";
+
+        use std::io::Write;
+
+        use tempfile::NamedTempFile;
+        // Create a file inside of `std::env::temp_dir()`.
+        let mut file1 = NamedTempFile::new().unwrap();
+
+        // Write some test data to the first handle.
+        file1.write_all(data.as_bytes()).unwrap();
+        let p = file1.path().to_str().unwrap();
+        load_data_with_features(
+            p,
+            plaintext_keys.clone(),
+            plaintext_features,
+            self_num_features,
+            self_num_records,
+        );
+
+        assert_eq!(plaintext_keys.read().unwrap().len(), 3);
+    }
 }


### PR DESCRIPTION
Summary:
# What
* Add unit test for decrypt and enc_serialise in paillier. Check the length of the vector is same or not.
* change should_panic(msg) to should_panic due to it cannot be detected by the code coverage tool.
* Add unit test for load_data_with_features. Load file and check the number of plain keys.

# Why
* need to improve code coverage

Differential Revision: D40495543

