### PR TITLE
Add unit test for tls and streaming

### DIFF
--- a/protocol-rpc/Cargo.toml
+++ b/protocol-rpc/Cargo.toml
@@ -92,7 +92,7 @@ itertools = "0.9.0"
 tempfile = "3.2.0"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
-
+rcgen = "0.10.0"
 
 [build-dependencies]
 tonic-build = { version = "0.7.2" }

--- a/protocol-rpc/src/proto/streaming.rs
+++ b/protocol-rpc/src/proto/streaming.rs
@@ -54,3 +54,42 @@ pub fn write_to_stream(payload: TPayload) -> Response<TPayloadStream> {
     });
     Response::new(ReceiverStream::new(rx))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_data() {
+        let data = vec![
+            ByteBuffer {
+                buffer: vec![
+                    200, 135, 56, 19, 5, 207, 16, 147, 198, 229, 224, 111, 97, 119, 247, 238, 48,
+                    209, 55, 188, 30, 178, 53, 4, 110, 27, 182, 220, 156, 57, 53, 63,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    102, 237, 233, 208, 207, 235, 165, 5, 177, 27, 168, 233, 239, 69, 163, 80, 155,
+                    2, 85, 192, 182, 25, 20, 189, 118, 5, 225, 153, 13, 254, 201, 40,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    48, 54, 39, 197, 69, 34, 214, 167, 225, 117, 64, 223, 51, 164, 33, 208, 18,
+                    108, 38, 248, 215, 189, 94, 180, 82, 105, 196, 43, 189, 2, 220, 6,
+                ],
+            },
+            ByteBuffer {
+                buffer: vec![
+                    228, 188, 46, 30, 21, 100, 156, 96, 162, 185, 103, 149, 89, 159, 81, 67, 119,
+                    112, 0, 174, 99, 188, 74, 7, 13, 236, 98, 48, 50, 145, 156, 50,
+                ],
+            },
+        ];
+
+        let p = Payload::from(&data);
+        let tp = TPayload::from(&p);
+        send_data(tp);
+    }
+}


### PR DESCRIPTION
Summary:
# What
* Add unit test for tls. Use rcgen to create the cert and pem and run from_dir()
* Add unit test for send_data. Just send the payload and see whether it can finish or not

# Why
* need to improve code coverage

Differential Revision: D40660872

