### PR TITLE
1/2: Rust oneway tls support

### DIFF
--- a/protocol-rpc/src/connect/create_client.rs
+++ b/protocol-rpc/src/connect/create_client.rs
@@ -1,6 +1,7 @@
 //  Copyright (c) Facebook, Inc. and its affiliates.
 //  SPDX-License-Identifier: Apache-2.0
 
+use std::env;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -37,12 +38,23 @@ pub fn create_client(
     } else {
         match (tls_dir, tls_key, tls_cert, tls_ca) {
             (Some(d), None, None, None) => {
-                info!("using dir for tls files {}", d);
+                info!("using dir for TLS files {}", d);
                 Some(tls::TlsContext::from_dir(d, false))
             }
+            // Two-way TLS support
             (None, Some(key), Some(cert), Some(ca)) => {
-                debug!("using paths directly to read the files");
+                debug!("using paths directly to read TLS files");
                 Some(tls::TlsContext::from_paths(key, cert, ca))
+            }
+            // One-way TLS support
+            (None, None, None, Some(ca)) => {
+                let full_ca_path = if env::var("HOME").is_ok() {
+                    env::var("HOME").unwrap() + "/" + ca
+                } else {
+                    "/".to_owned() + ca
+                };
+                info!("full ca path: {}", full_ca_path);
+                Some(tls::TlsContext::from_path_client(full_ca_path.as_str()))
             }
             _ => {
                 let msg = "Supporting --tls-dir together with direct paths is not supported yet";
@@ -62,7 +74,7 @@ pub fn create_client(
                     .domain()
                     .unwrap_or_else(|| {
                         panic!(
-                            "Cannot extract domain neither from host {}\
+                            "Cannot extract domain neither from host {} \
                          nor --tls-domain arg was specified",
                             host
                         )
@@ -71,16 +83,26 @@ pub fn create_client(
             };
 
             info!(
-                "tls domain name: {} (--tls-domain can can override)",
+                "tls domain name: {} (--tls-domain can override)",
                 domain_name
             );
 
-            Some(
-                ClientTlsConfig::new()
-                    .domain_name(domain_name)
-                    .identity(ctx.identity)
-                    .ca_certificate(ctx.ca),
-            )
+            if ctx.identity.is_some() {
+                // Two-way TLS
+                Some(
+                    ClientTlsConfig::new()
+                        .domain_name(domain_name)
+                        .identity(ctx.identity.unwrap())
+                        .ca_certificate(ctx.ca.unwrap()),
+                )
+            } else {
+                // One-way TLS
+                Some(
+                    ClientTlsConfig::new()
+                        .domain_name(domain_name)
+                        .ca_certificate(ctx.ca.unwrap()),
+                )
+            }
         }
         None => None,
     };
@@ -180,5 +202,41 @@ mod test {
             tls_domain,
             "private-id-multi-key".to_string(),
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "ca.pem not found")]
+    fn test_create_client_with_oneway_tls() {
+        use std::fs::File;
+        use std::io::Write;
+
+        use tempfile::tempdir;
+
+        // Create a directory inside of `std::env::temp_dir()`.
+        let dir = tempdir().unwrap();
+        use rcgen::*;
+        let ca_subject_alt_names: &[_] = &["ca.world.example".to_string(), "localhost".to_string()];
+
+        let ca_cert = generate_simple_self_signed(ca_subject_alt_names).unwrap();
+        let ca_pem = ca_cert.serialize_pem().unwrap();
+
+        let file_path_ca_pem = dir.path().join("ca.pem");
+        let mut file_ca_pem = File::create(file_path_ca_pem).unwrap();
+        file_ca_pem.write_all(ca_pem.as_bytes()).unwrap();
+
+        // create_client will use HOME env as the prefix of path, not temp dir, it will throw pem not found error
+        let _ = create_client(
+            false,
+            Some("localhost:10009"),
+            None,
+            None,
+            None,
+            Some("ca.pem"),
+            Some("localhost"),
+            "private-id-multi-key".to_string(),
+        );
+
+        drop(file_ca_pem);
+        dir.close().unwrap();
     }
 }

--- a/protocol-rpc/src/connect/create_server.rs
+++ b/protocol-rpc/src/connect/create_server.rs
@@ -1,6 +1,8 @@
 //  Copyright (c) Facebook, Inc. and its affiliates.
 //  SPDX-License-Identifier: Apache-2.0
 
+use std::env;
+
 use log::info;
 use log::warn;
 use tonic::transport::Server;
@@ -25,12 +27,32 @@ pub fn create_server(
     } else {
         match (tls_dir, tls_key, tls_cert, tls_ca) {
             (Some(d), None, None, None) => {
-                info!("using dir for tls files {}", d);
+                info!("using dir for TLS files {}", d);
                 Some(tls::TlsContext::from_dir(d, true))
             }
+            // Two-way TLS
             (None, Some(key), Some(cert), Some(ca)) => {
-                debug!("using paths diretcly to read the files");
+                debug!("using paths directly to read the files");
                 Some(tls::TlsContext::from_paths(key, cert, ca))
+            }
+            // One-way TLS
+            (None, Some(key), Some(cert), None) => {
+                let full_key_path = if env::var("HOME").is_ok() {
+                    env::var("HOME").unwrap() + "/" + key
+                } else {
+                    "/".to_owned() + key
+                };
+                let full_cert_path = if env::var("HOME").is_ok() {
+                    env::var("HOME").unwrap() + "/" + cert
+                } else {
+                    "/".to_owned() + cert
+                };
+                info!("full key path: {}", full_key_path);
+                info!("full cert path: {}", full_cert_path);
+                Some(tls::TlsContext::from_paths_server(
+                    full_key_path.as_str(),
+                    full_cert_path.as_str(),
+                ))
             }
             _ => {
                 let msg = "Supporting --tls-dir together with direct paths is not supported yet";
@@ -49,13 +71,21 @@ pub fn create_server(
     server = match tls_context {
         Some(ctx) => {
             info!("Starting server with TLS support");
-            server
-                .tls_config(
-                    ServerTlsConfig::new()
-                        .identity(ctx.identity)
-                        .client_ca_root(ctx.ca),
-                )
-                .unwrap()
+            if ctx.ca.is_some() {
+                // Two-way TLS
+                server
+                    .tls_config(
+                        ServerTlsConfig::new()
+                            .identity(ctx.identity.unwrap())
+                            .client_ca_root(ctx.ca.unwrap()),
+                    )
+                    .unwrap()
+            } else {
+                // One-way TLS
+                server
+                    .tls_config(ServerTlsConfig::new().identity(ctx.identity.unwrap()))
+                    .unwrap()
+            }
         }
         None => server,
     };
@@ -75,5 +105,38 @@ mod test {
     #[should_panic]
     fn test_create_server_tls_panic() {
         let _ = create_server(false, None, None, None, None);
+    }
+
+    #[test]
+    #[should_panic(expected = "private.key not found")]
+    fn test_create_server_with_oneway_tls() {
+        use std::fs::File;
+        use std::io::Write;
+
+        use tempfile::tempdir;
+
+        // Create a directory inside of `std::env::temp_dir()`.
+        let dir = tempdir().unwrap();
+        use rcgen::*;
+        let subject_alt_names: &[_] = &["hello.world.example".to_string(), "localhost".to_string()];
+
+        let server_cert = generate_simple_self_signed(subject_alt_names).unwrap();
+        let server_pem = server_cert.serialize_pem().unwrap();
+        let private_key = server_cert.serialize_private_key_pem();
+
+        let file_path_server_pem = dir.path().join("server.pem");
+        let mut file_server_pem = File::create(file_path_server_pem).unwrap();
+        file_server_pem.write_all(server_pem.as_bytes()).unwrap();
+
+        let file_path_private_key = dir.path().join("private.key");
+        let mut file_private_key = File::create(file_path_private_key).unwrap();
+        file_private_key.write_all(private_key.as_bytes()).unwrap();
+
+        // create_server will use HOME env as the prefix of path, not temp dir, it will throw key not found error
+        let _ = create_server(false, None, Some("private.key"), Some("server.pem"), None);
+
+        drop(file_server_pem);
+        drop(file_private_key);
+        dir.close().unwrap();
     }
 }

--- a/protocol-rpc/src/rpc/cross-psi-xor/client.rs
+++ b/protocol-rpc/src/rpc/cross-psi-xor/client.rs
@@ -95,8 +95,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -105,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/cross-psi-xor/server.rs
+++ b/protocol-rpc/src/rpc/cross-psi-xor/server.rs
@@ -72,13 +72,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",

--- a/protocol-rpc/src/rpc/cross-psi/client.rs
+++ b/protocol-rpc/src/rpc/cross-psi/client.rs
@@ -85,8 +85,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -95,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/cross-psi/server.rs
+++ b/protocol-rpc/src/rpc/cross-psi/server.rs
@@ -69,13 +69,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",

--- a/protocol-rpc/src/rpc/pjc/client.rs
+++ b/protocol-rpc/src/rpc/pjc/client.rs
@@ -81,8 +81,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -91,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/pjc/server.rs
+++ b/protocol-rpc/src/rpc/pjc/server.rs
@@ -65,13 +65,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",

--- a/protocol-rpc/src/rpc/private-id-multi-key/client.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/client.rs
@@ -93,8 +93,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -108,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/private-id-multi-key/server.rs
+++ b/protocol-rpc/src/rpc/private-id-multi-key/server.rs
@@ -77,13 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",

--- a/protocol-rpc/src/rpc/private-id/client.rs
+++ b/protocol-rpc/src/rpc/private-id/client.rs
@@ -93,8 +93,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -116,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/private-id/server.rs
+++ b/protocol-rpc/src/rpc/private-id/server.rs
@@ -77,13 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",

--- a/protocol-rpc/src/rpc/suid-create/client.rs
+++ b/protocol-rpc/src/rpc/suid-create/client.rs
@@ -86,8 +86,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::with_name("tls-ca")
                 .long("tls-ca")
                 .takes_value(true)
-                .requires("tls-key")
-                .requires("tls-cert")
                 .help("Path to root CA certificate issued cert and keys"),
             Arg::with_name("tls-domain")
                 .long("tls-domain")
@@ -96,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])
         .groups(&[
             ArgGroup::with_name("tls")
-                .args(&["no-tls", "tls-dir", "tls-key"])
+                .args(&["no-tls", "tls-dir", "tls-ca"])
                 .required(true),
             ArgGroup::with_name("out")
                 .args(&["output", "stdout"])

--- a/protocol-rpc/src/rpc/suid-create/server.rs
+++ b/protocol-rpc/src/rpc/suid-create/server.rs
@@ -71,13 +71,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("tls-key")
                 .takes_value(true)
                 .requires("tls-cert")
-                .requires("tls-ca")
                 .help("Path to tls key (non-encrypted)"),
             Arg::with_name("tls-cert")
                 .long("tls-cert")
                 .takes_value(true)
                 .requires("tls-key")
-                .requires("tls-ca")
                 .help(
                     "Path to tls certificate (pem format), SINGLE cert, \
                      NO CHAINING, required by client as well",


### PR DESCRIPTION
Summary: Add support for rust PID binary oneway TLS

Reviewed By: danbunnell

Differential Revision: D43613367

