### PR TITLE
clippy: prevent holding a span guard over an `.await`

### DIFF
--- a/tools/rust/ossconfigs/clippy.toml
+++ b/tools/rust/ossconfigs/clippy.toml
@@ -1,1 +1,5 @@
 too-many-lines-threshold = 200
+await-holding-invalid-types = [
+    { path = "tracing::span::Entered", reason = "`Entered` is not aware when a function is suspended: https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code" },
+    { path = "tracing::span::EnteredSpan", reason = "`EnteredSpan` is not aware when a function is suspended: https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code" },
+]


### PR DESCRIPTION
Summary: We should probably lint against using an `.enter()` guard over `.await` points for the reasons outlined in https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code.

Reviewed By: zertosh

Differential Revision: D50528695


